### PR TITLE
Updating proguard rules

### DIFF
--- a/Java/app/proguard-rules.pro
+++ b/Java/app/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep specific scroll-related interfaces for Taboola
+-keep interface androidx.core.view.NestedScrollingChild
+-keep interface androidx.core.view.NestedScrollingChild2
+-keep interface androidx.core.view.NestedScrollingChild3
+-keep interface androidx.core.view.ScrollingView

--- a/Kotlin/app/proguard-rules.pro
+++ b/Kotlin/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+
+# Keep specific scroll-related interfaces for Taboola
+-keep interface androidx.core.view.NestedScrollingChild
+-keep interface androidx.core.view.NestedScrollingChild2
+-keep interface androidx.core.view.NestedScrollingChild3
+-keep interface androidx.core.view.ScrollingView


### PR DESCRIPTION
In order to better reflect the needed proguard rules for publishers, this PR updates the relevant proguard rules for the SDK4 project, for both the Java and Kotlin variants.