### PR TITLE
MOB-5807 Added Interstitial screen

### DIFF
--- a/Java/app/build.gradle
+++ b/Java/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.0"
 
     //Taboola
-    implementation 'com.taboola:android-sdk-beta:4.0.24-rc1-502-a83c67def' //TODO: Change to the official SDK 4 version when it's ready.
+    implementation 'com.taboola:android-sdk:4.0.24'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
 }

--- a/Java/app/build.gradle
+++ b/Java/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.0"
 
     //Taboola
-    implementation 'com.taboola:android-sdk:4.0.22'
+    implementation 'com.taboola:android-sdk-beta:4.0.24-rc1-502-a83c67def' //TODO: Change to the official SDK 4 version when it's ready.
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
 }

--- a/Java/app/src/main/java/com/taboola/sdk4example/Const.java
+++ b/Java/app/src/main/java/com/taboola/sdk4example/Const.java
@@ -27,4 +27,9 @@ public class Const {
     //Explore More
     public static final String EXPLORE_MORE_PLACEMENT_NAME =  "Feed - Explore More";
     public static final String EXPLORE_MORE_CUSTOM_SEGMENT_SUBSCRIBER =  "subscriber";
+
+    //Interstitial
+    public static final String INTERSTITIAL_PLACEMENT_NAME = "Trigger Interstitial";
+    public static final String INTERSTITIAL_MODE = "full-screen-interstitial-test";
+    public static final String INTERSTITIAL_CUSTOM_SEGMENT_DEFAULT = "Vignette";
 }

--- a/Java/app/src/main/java/com/taboola/sdk4example/SDKClassicMenuFragment.java
+++ b/Java/app/src/main/java/com/taboola/sdk4example/SDKClassicMenuFragment.java
@@ -19,6 +19,7 @@ import com.taboola.sdk4example.sdk_classic.FeedWithMiddleArticleDarkModeInsideRe
 import com.taboola.sdk4example.sdk_classic.FeedWithMiddleArticleInsideListViewFragment;
 import com.taboola.sdk4example.sdk_classic.FeedWithMiddleArticleInsideRecyclerViewFragment;
 import com.taboola.sdk4example.sdk_classic.FeedWithMiddleArticleInsideScrollViewFragment;
+import com.taboola.sdk4example.sdk_classic.InterstitialFragment;
 import com.taboola.sdk4example.sdk_classic.OCClickHandlerFragment;
 import com.taboola.sdk4example.sdk_classic.PullToRefreshFragment;
 import com.taboola.sdk4example.sdk_classic.RecyclerViewPreloadFragment;
@@ -68,6 +69,7 @@ public class SDKClassicMenuFragment extends Fragment implements View.OnClickList
         addButton(getString(R.string.std_feed_lazy_loading_rv), R.id.std_feed_lazy_loading_rv, viewGroup);
         addButton(getString(R.string.std_mid_article_with_feed_dark_mode_rv), R.id.std_mid_article_with_feed_dark_mode_rv, viewGroup);
         addButton(getString(R.string.std_explore_more), R.id.std_explore_more, viewGroup);
+        addButton(getString(R.string.std_interstitial), R.id.std_interstitial, viewGroup);
     }
 
 
@@ -113,6 +115,9 @@ public class SDKClassicMenuFragment extends Fragment implements View.OnClickList
                 Intent intent = new Intent(getContext(), ExploreMoreActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                 startActivity(intent);
+                break;
+            case R.id.std_interstitial:
+                fragmentToOpen = new InterstitialFragment();
                 break;
         }
 

--- a/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
+++ b/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
@@ -58,7 +58,7 @@ public class InterstitialFragment extends Fragment {
         Button showInterstitialButton = view.findViewById(R.id.show_interstitial_btn);
 
         tblClassicPage = Taboola.getClassicPage(Const.PAGE_URL, Const.PAGE_TYPE);
-        TBLClassicInterstitialListener listener = new TBLClassicInterstitialListener() {
+        TBLClassicInterstitialListener tblClassicInterstitialListener = new TBLClassicInterstitialListener() {
             @Override
             public void onInterstitialLoaded() {
                 super.onInterstitialLoaded();
@@ -111,7 +111,7 @@ public class InterstitialFragment extends Fragment {
                 Const.INTERSTITIAL_PLACEMENT_NAME,
                 Const.INTERSTITIAL_MODE,
                 Const.INTERSTITIAL_CUSTOM_SEGMENT_DEFAULT,
-                listener
+                tblClassicInterstitialListener
         );
 
         tblClassicPage.loadInterstitial();

--- a/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
+++ b/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
@@ -19,6 +19,23 @@ import com.taboola.android.listeners.TBLClassicInterstitialListener;
 import com.taboola.sdk4example.Const;
 import com.taboola.sdk4example.R;
 
+/**
+ * Shows a Taboola Classic interstitial flow.
+ * <p>
+ * This fragment initializes a Classic page and demonstrates how to load and present
+ * a full-screen interstitial using the Taboola SDK.
+ * <p>
+ * Interstitial implementation overview:
+ * <ul>
+ *     <li>Creates a {@link TBLClassicPage} with the page URL/type from {@link Const}.</li>
+ *     <li>Initializes the interstitial placement with placement name, mode, and custom segment.</li>
+ *     <li>Loads the ad immediately; the loading UI is visible until {@code onInterstitialLoaded}.</li>
+ *     <li>Enables the "show" button only after a successful load to avoid empty presentation.</li>
+ *     <li>Presents the interstitial on user action and reacts to lifecycle callbacks
+ *     (presented/dismissed/clicked) for UI updates and logging.</li>
+ *     <li>If loading fails, the loading UI is hidden and the error is surfaced to the user.</li>
+ * </ul>
+ */
 public class InterstitialFragment extends Fragment {
 
     private static final String TAG = InterstitialFragment.class.getSimpleName();
@@ -30,6 +47,9 @@ public class InterstitialFragment extends Fragment {
         return inflater.inflate(R.layout.fragment_interstitial, container, false);
     }
 
+    /**
+     * Initializes the Taboola Classic page, sets up callbacks, and loads the interstitial.
+     */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);

--- a/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
+++ b/Java/app/src/main/java/com/taboola/sdk4example/sdk_classic/InterstitialFragment.java
@@ -1,0 +1,104 @@
+package com.taboola.sdk4example.sdk_classic;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.taboola.android.TBLClassicPage;
+import com.taboola.android.Taboola;
+import com.taboola.android.listeners.TBLClassicInterstitialListener;
+import com.taboola.sdk4example.Const;
+import com.taboola.sdk4example.R;
+
+public class InterstitialFragment extends Fragment {
+
+    private static final String TAG = InterstitialFragment.class.getSimpleName();
+    private TBLClassicPage tblClassicPage;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_interstitial, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        LinearLayout interstitialLoadingContainer = view.findViewById(R.id.interstitial_loading_container);
+        Button showInterstitialButton = view.findViewById(R.id.show_interstitial_btn);
+
+        tblClassicPage = Taboola.getClassicPage(Const.PAGE_URL, Const.PAGE_TYPE);
+        TBLClassicInterstitialListener listener = new TBLClassicInterstitialListener() {
+            @Override
+            public void onInterstitialLoaded() {
+                super.onInterstitialLoaded();
+                interstitialLoadingContainer.setVisibility(View.GONE);
+                showInterstitialButton.setVisibility(View.VISIBLE);
+                Log.d(TAG, "The Interstitial is loaded successfully.");
+            }
+
+            @Override
+            public void onInterstitialWillPresent() {
+                super.onInterstitialWillPresent();
+                Log.d(TAG, "The Interstitial will be presented.");
+            }
+
+            @Override
+            public void onInterstitialPresented() {
+                super.onInterstitialPresented();
+                showInterstitialButton.setVisibility(View.GONE);
+                Log.d(TAG, "The Interstitial is presented.");
+            }
+
+            @Override
+            public void onInterstitialWillDismiss() {
+                super.onInterstitialWillDismiss();
+                Log.d(TAG, "The Interstitial will be dismissed.");
+            }
+
+            @Override
+            public void onInterstitialDismissed() {
+                super.onInterstitialDismissed();
+                Log.d(TAG, "The Interstitial is dismissed.");
+            }
+
+            @Override
+            public void onInterstitialClicked() {
+                super.onInterstitialClicked();
+                Log.d(TAG, "The Interstitial is clicked.");
+            }
+
+            @Override
+            public void interstitialDidFailToLoadAdWithError(String error) {
+                super.interstitialDidFailToLoadAdWithError(error);
+                interstitialLoadingContainer.setVisibility(View.GONE);
+                Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show();
+                Log.d(TAG, error);
+            }
+        };
+
+        tblClassicPage.initInterstitial(
+                Const.INTERSTITIAL_PLACEMENT_NAME,
+                Const.INTERSTITIAL_MODE,
+                Const.INTERSTITIAL_CUSTOM_SEGMENT_DEFAULT,
+                listener
+        );
+
+        tblClassicPage.loadInterstitial();
+
+        showInterstitialButton.setOnClickListener(v -> {
+            tblClassicPage.showInterstitial();
+        });
+    }
+}
+

--- a/Java/app/src/main/res/layout/fragment_interstitial.xml
+++ b/Java/app/src/main/res/layout/fragment_interstitial.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/main_lyt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:layout_marginBottom="10dp"
+            android:text="@string/fake_text" />
+
+        <LinearLayout
+            android:id="@+id/interstitial_loading_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp" />
+
+            <TextView
+                android:id="@+id/loading_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/interstitial_loading" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/show_interstitial_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="@string/interstitial_show"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+</ScrollView>
+

--- a/Java/app/src/main/res/values/ids.xml
+++ b/Java/app/src/main/res/values/ids.xml
@@ -19,6 +19,7 @@
     <item name="std_feed_lazy_loading_rv" type="id" />
     <item name="std_mid_article_with_feed_dark_mode_rv" type="id" />
     <item name="std_explore_more" type="id" />
+    <item name="std_interstitial" type="id" />
     <item name="native_widget" type="id" />
     <item name="native_feed" type="id" />
 

--- a/Java/app/src/main/res/values/strings.xml
+++ b/Java/app/src/main/res/values/strings.xml
@@ -107,9 +107,12 @@ These will help you remember what the consumer really wants to engage with and w
     <string name="std_feed_lazy_loading_rv">Feed Lazy Loading (RecyclerView)</string>
     <string name="std_mid_article_with_feed_dark_mode_rv">Feed with Dark Mode (RecyclerView)</string>
     <string name="std_explore_more">Explore More</string>
+    <string name="std_interstitial">Interstitial</string>
     <string name="show_explore_more">Show Explore More</string>
     <string name="set_back_button_trigger">Set Back Button Trigger</string>
     <string name="explore_more_loading">Explore More Loading</string>
+    <string name="interstitial_loading">Loading Interstitial</string>
+    <string name="interstitial_show">Show Interstitial</string>
     <string name="native_widget">Native Widget</string>
     <string name="native_feed">Native Feed</string>
     <!-- TODO: Remove or change this placeholder text -->

--- a/Kotlin/app/build.gradle
+++ b/Kotlin/app/build.gradle
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     // Import Taboola SDK
-    implementation 'com.taboola:android-sdk-beta:4.0.24-rc1-502-a83c67def'  //TODO: Change to the official SDK 4 version when it's ready.
+    implementation 'com.taboola:android-sdk:4.0.24'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'

--- a/Kotlin/app/build.gradle
+++ b/Kotlin/app/build.gradle
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     // Import Taboola SDK
-    implementation 'com.taboola:android-sdk:4.0.22'
+    implementation 'com.taboola:android-sdk-beta:4.0.24-rc1-502-a83c67def'  //TODO: Change to the official SDK 4 version when it's ready.
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/MainActivity.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/MainActivity.kt
@@ -27,7 +27,8 @@ class MainActivity : AppCompatActivity() {
         R.id.nav_native_widget,
         R.id.nav_native_feed,
         R.id.nav_classic_explore_more,
-        R.id.nav_classic_explore_more_compose
+        R.id.nav_classic_explore_more_compose,
+        R.id.nav_classic_interstitial
     )
 
     // Fragments that should become root screens (back button exits app)

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/MainActivity.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/MainActivity.kt
@@ -28,7 +28,8 @@ class MainActivity : AppCompatActivity() {
         R.id.nav_native_feed,
         R.id.nav_classic_explore_more,
         R.id.nav_classic_explore_more_compose,
-        R.id.nav_classic_interstitial
+        R.id.nav_classic_interstitial,
+        R.id.nav_classic_interstitial_compose
     )
 
     // Fragments that should become root screens (back button exits app)

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/PlacementInfo.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/PlacementInfo.kt
@@ -46,6 +46,14 @@ class PlacementInfo {
         val customSegment = "subscriber"
     }
 
+    class InterstitialProperties {
+        val placementName = "Trigger Interstitial"
+        val pageType = "article"
+        val pageUrl = "https://blog.taboola.com"
+        val mode = "full-screen-interstitial-test"
+        val customSegment = "Vignette"
+    }
+
     // Static access
     companion object {
         fun widgetProperties() = WidgetProperties()
@@ -54,6 +62,7 @@ class PlacementInfo {
         fun nativeFeedProperties() = NativeFeedProperties()
         fun webFeedProperties() = WebFeedProperties()
         fun exploreMoreProperties() = ExploreMoreProperties()
+        fun interstitialProperties() = InterstitialProperties()
     }
 
 

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/ClassicInterstitialComposeFragment.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/ClassicInterstitialComposeFragment.kt
@@ -1,0 +1,167 @@
+package com.taboola.kotlin.examples.screens.classic
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import com.taboola.android.TBLClassicPage
+import com.taboola.android.Taboola
+import com.taboola.android.listeners.TBLClassicInterstitialListener
+import com.taboola.kotlin.examples.PlacementInfo
+import com.taboola.kotlin.examples.R
+
+/**
+ * Compose sample for the Taboola Classic interstitial flow.
+ *
+ * The screen loads an interstitial when entering the fragment and enables the
+ * "Show Interstitial" button only after a successful load.
+ */
+class ClassicInterstitialComposeFragment : Fragment() {
+
+    private lateinit var tblClassicPage: TBLClassicPage
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val interstitialProperties = PlacementInfo.interstitialProperties()
+        tblClassicPage = Taboola.getClassicPage(
+            interstitialProperties.pageUrl,
+            interstitialProperties.pageType
+        )
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                InterstitialComposeScreen(
+                    tblClassicPage = tblClassicPage,
+                    interstitialProperties = interstitialProperties,
+                    onError = { error ->
+                        Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
+                    }
+                )
+            }
+        }
+    }
+
+    companion object {
+        val TAG = ClassicInterstitialComposeFragment::class.java.simpleName
+    }
+}
+
+@Composable
+private fun InterstitialComposeScreen(
+    tblClassicPage: TBLClassicPage,
+    interstitialProperties: PlacementInfo.InterstitialProperties,
+    onError: (String) -> Unit
+) {
+    var isLoading by remember { mutableStateOf(true) }
+    var canShowInterstitial by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(Unit) {
+        tblClassicPage.initInterstitial(
+            interstitialProperties.placementName,
+            interstitialProperties.mode,
+            interstitialProperties.customSegment,
+            object : TBLClassicInterstitialListener() {
+                override fun onInterstitialLoaded() {
+                    super.onInterstitialLoaded()
+                    isLoading = false
+                    canShowInterstitial = true
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is loaded successfully.")
+                }
+
+                override fun onInterstitialWillPresent() {
+                    super.onInterstitialWillPresent()
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial will be presented.")
+                }
+
+                override fun onInterstitialPresented() {
+                    super.onInterstitialPresented()
+                    canShowInterstitial = false
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is presented.")
+                }
+
+                override fun onInterstitialWillDismiss() {
+                    super.onInterstitialWillDismiss()
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial will be dismissed.")
+                }
+
+                override fun onInterstitialDismissed() {
+                    super.onInterstitialDismissed()
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is dismissed.")
+                }
+
+                override fun onInterstitialClicked() {
+                    super.onInterstitialClicked()
+                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is clicked.")
+                }
+
+                override fun interstitialDidFailToLoadAdWithError(error: String) {
+                    super.interstitialDidFailToLoadAdWithError(error)
+                    isLoading = false
+                    onError(error)
+                    Log.d(ClassicInterstitialComposeFragment.TAG, error)
+                }
+            }
+        )
+
+        tblClassicPage.loadInterstitial()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = stringResource(id = R.string.lorem_ipsum))
+
+        if (isLoading) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                CircularProgressIndicator()
+                Text(text = stringResource(id = R.string.interstitial_loading))
+            }
+        }
+
+        if (canShowInterstitial) {
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { tblClassicPage.showInterstitial() }
+            ) {
+                Text(text = stringResource(id = R.string.interstitial_show))
+            }
+        }
+    }
+}

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/ClassicInterstitialComposeFragment.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/ClassicInterstitialComposeFragment.kt
@@ -18,10 +18,8 @@ import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +42,8 @@ import com.taboola.kotlin.examples.R
 class ClassicInterstitialComposeFragment : Fragment() {
 
     private lateinit var tblClassicPage: TBLClassicPage
+    private var isLoading by mutableStateOf(true)
+    private var canShowInterstitial by mutableStateOf(false)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -55,36 +55,8 @@ class ClassicInterstitialComposeFragment : Fragment() {
             interstitialProperties.pageUrl,
             interstitialProperties.pageType
         )
-
-        return ComposeView(requireContext()).apply {
-            setContent {
-                InterstitialComposeScreen(
-                    tblClassicPage = tblClassicPage,
-                    interstitialProperties = interstitialProperties,
-                    onError = { error ->
-                        Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
-                    }
-                )
-            }
-        }
-    }
-
-    companion object {
-        val TAG = ClassicInterstitialComposeFragment::class.java.simpleName
-    }
-}
-
-@Composable
-private fun InterstitialComposeScreen(
-    tblClassicPage: TBLClassicPage,
-    interstitialProperties: PlacementInfo.InterstitialProperties,
-    onError: (String) -> Unit
-) {
-    var isLoading by remember { mutableStateOf(true) }
-    var canShowInterstitial by remember { mutableStateOf(false) }
-    val scrollState = rememberScrollState()
-
-    LaunchedEffect(Unit) {
+        isLoading = true
+        canShowInterstitial = false
         tblClassicPage.initInterstitial(
             interstitialProperties.placementName,
             interstitialProperties.mode,
@@ -94,46 +66,68 @@ private fun InterstitialComposeScreen(
                     super.onInterstitialLoaded()
                     isLoading = false
                     canShowInterstitial = true
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is loaded successfully.")
+                    Log.d(TAG, "The Interstitial is loaded successfully.")
                 }
 
                 override fun onInterstitialWillPresent() {
                     super.onInterstitialWillPresent()
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial will be presented.")
+                    Log.d(TAG, "The Interstitial will be presented.")
                 }
 
                 override fun onInterstitialPresented() {
                     super.onInterstitialPresented()
                     canShowInterstitial = false
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is presented.")
+                    Log.d(TAG, "The Interstitial is presented.")
                 }
 
                 override fun onInterstitialWillDismiss() {
                     super.onInterstitialWillDismiss()
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial will be dismissed.")
+                    Log.d(TAG, "The Interstitial will be dismissed.")
                 }
 
                 override fun onInterstitialDismissed() {
                     super.onInterstitialDismissed()
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is dismissed.")
+                    Log.d(TAG, "The Interstitial is dismissed.")
                 }
 
                 override fun onInterstitialClicked() {
                     super.onInterstitialClicked()
-                    Log.d(ClassicInterstitialComposeFragment.TAG, "The Interstitial is clicked.")
+                    Log.d(TAG, "The Interstitial is clicked.")
                 }
 
                 override fun interstitialDidFailToLoadAdWithError(error: String) {
                     super.interstitialDidFailToLoadAdWithError(error)
                     isLoading = false
-                    onError(error)
-                    Log.d(ClassicInterstitialComposeFragment.TAG, error)
+                    Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
+                    Log.d(TAG, error)
                 }
             }
         )
-
         tblClassicPage.loadInterstitial()
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                InterstitialComposeScreen(
+                    tblClassicPage = tblClassicPage,
+                    isLoading = isLoading,
+                    canShowInterstitial = canShowInterstitial
+                )
+            }
+        }
     }
+
+    companion object {
+        val TAG = this::class.java.simpleName
+    }
+}
+
+@Composable
+private fun InterstitialComposeScreen(
+    tblClassicPage: TBLClassicPage,
+    isLoading: Boolean,
+    canShowInterstitial: Boolean
+) {
+    val scrollState = rememberScrollState()
 
     Column(
         modifier = Modifier

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
@@ -1,0 +1,100 @@
+package com.taboola.kotlin.examples.screens.classic
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import com.taboola.android.TBLClassicPage
+import com.taboola.android.Taboola
+import com.taboola.android.listeners.TBLClassicInterstitialListener
+import com.taboola.kotlin.examples.PlacementInfo
+import com.taboola.kotlin.examples.R
+
+class InterstitialFragment : Fragment() {
+
+    private lateinit var tblClassicPage: TBLClassicPage
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_classic_interstitial, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val interstitialLoadingContainer = view.findViewById<LinearLayout>(R.id.interstitial_loading_container)
+        val showInterstitialButton = view.findViewById<Button>(R.id.show_interstitial_btn)
+
+        val properties = PlacementInfo.interstitialProperties()
+        tblClassicPage = Taboola.getClassicPage(properties.pageUrl, properties.pageType)
+
+        val listener = object : TBLClassicInterstitialListener() {
+            override fun onInterstitialLoaded() {
+                super.onInterstitialLoaded()
+                interstitialLoadingContainer.isVisible = false
+                showInterstitialButton.isVisible = true
+                Log.d(TAG, "The Interstitial is loaded successfully.")
+            }
+
+            override fun onInterstitialWillPresent() {
+                super.onInterstitialWillPresent()
+                Log.d(TAG, "The Interstitial will be presented.")
+            }
+
+            override fun onInterstitialPresented() {
+                super.onInterstitialPresented()
+                showInterstitialButton.isVisible = false
+                Log.d(TAG, "The Interstitial is presented.")
+            }
+
+            override fun onInterstitialWillDismiss() {
+                super.onInterstitialWillDismiss()
+                Log.d(TAG, "The Interstitial will be dismissed.")
+            }
+
+            override fun onInterstitialDismissed() {
+                super.onInterstitialDismissed()
+                Log.d(TAG, "The Interstitial is dismissed.")
+            }
+
+            override fun onInterstitialClicked() {
+                super.onInterstitialClicked()
+                Log.d(TAG, "The Interstitial is clicked.")
+            }
+
+            override fun interstitialDidFailToLoadAdWithError(error: String) {
+                super.interstitialDidFailToLoadAdWithError(error)
+                interstitialLoadingContainer.isVisible = false
+                Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
+                Log.d(TAG, error)
+            }
+        }
+
+        tblClassicPage.initInterstitial(
+            properties.placementName,
+            properties.mode,
+            properties.customSegment,
+            listener
+        )
+
+        tblClassicPage.loadInterstitial()
+
+        showInterstitialButton.setOnClickListener {
+            tblClassicPage.showInterstitial()
+        }
+    }
+
+    companion object {
+        private val TAG = InterstitialFragment::class.java.simpleName
+    }
+}
+

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
@@ -16,6 +16,22 @@ import com.taboola.android.listeners.TBLClassicInterstitialListener
 import com.taboola.kotlin.examples.PlacementInfo
 import com.taboola.kotlin.examples.R
 
+/**
+ * Shows a Taboola Classic interstitial flow.
+ *
+ * This fragment initializes a Classic page and demonstrates how to load and present
+ * a full-screen interstitial using the Taboola SDK.
+ *
+ * Interstitial implementation overview:
+ * - Creates a [TBLClassicPage] with the page URL/type from [PlacementInfo].
+ * - Initializes the interstitial placement with placement name, mode, and custom segment.
+ * - Loads the ad immediately; the loading UI is visible until
+ *   [TBLClassicInterstitialListener.onInterstitialLoaded].
+ * - Enables the "show" button only after a successful load to avoid empty presentation.
+ * - Presents the interstitial on user action and reacts to lifecycle callbacks
+ *   (presented/dismissed/clicked) for UI updates and logging.
+ * - If loading fails, the loading UI is hidden and the error is surfaced to the user.
+ */
 class InterstitialFragment : Fragment() {
 
     private lateinit var tblClassicPage: TBLClassicPage
@@ -28,6 +44,9 @@ class InterstitialFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_classic_interstitial, container, false)
     }
 
+    /**
+     * Initializes the Taboola Classic page, sets up callbacks, and loads the interstitial.
+     */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
+++ b/Kotlin/app/src/main/java/com/taboola/kotlin/examples/screens/classic/InterstitialFragment.kt
@@ -53,10 +53,10 @@ class InterstitialFragment : Fragment() {
         val interstitialLoadingContainer = view.findViewById<LinearLayout>(R.id.interstitial_loading_container)
         val showInterstitialButton = view.findViewById<Button>(R.id.show_interstitial_btn)
 
-        val properties = PlacementInfo.interstitialProperties()
-        tblClassicPage = Taboola.getClassicPage(properties.pageUrl, properties.pageType)
+        val interstitialProperties = PlacementInfo.interstitialProperties()
+        tblClassicPage = Taboola.getClassicPage(interstitialProperties.pageUrl, interstitialProperties.pageType)
 
-        val listener = object : TBLClassicInterstitialListener() {
+        val tblClassicInterstitialListener = object : TBLClassicInterstitialListener() {
             override fun onInterstitialLoaded() {
                 super.onInterstitialLoaded()
                 interstitialLoadingContainer.isVisible = false
@@ -99,10 +99,10 @@ class InterstitialFragment : Fragment() {
         }
 
         tblClassicPage.initInterstitial(
-            properties.placementName,
-            properties.mode,
-            properties.customSegment,
-            listener
+            interstitialProperties.placementName,
+            interstitialProperties.mode,
+            interstitialProperties.customSegment,
+            tblClassicInterstitialListener
         )
 
         tblClassicPage.loadInterstitial()

--- a/Kotlin/app/src/main/res/layout/fragment_classic_interstitial.xml
+++ b/Kotlin/app/src/main/res/layout/fragment_classic_interstitial.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/main_lyt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:layout_marginBottom="10dp"
+            android:text="@string/lorem_ipsum"
+            android:textSize="20sp" />
+
+        <LinearLayout
+            android:id="@+id/interstitial_loading_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp" />
+
+            <TextView
+                android:id="@+id/loading_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/interstitial_loading" />
+
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/show_interstitial_btn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="@string/interstitial_show"
+            android:visibility="gone" />
+
+    </LinearLayout>
+
+</ScrollView>
+

--- a/Kotlin/app/src/main/res/menu/activity_main_drawer.xml
+++ b/Kotlin/app/src/main/res/menu/activity_main_drawer.xml
@@ -29,6 +29,9 @@
             android:id="@+id/nav_classic_explore_more_compose"
             android:title="@string/classic_explore_more_compose" />
         <item
+            android:id="@+id/nav_classic_interstitial"
+            android:title="@string/classic_interstitial" />
+        <item
             android:id="@+id/nav_web_widget"
             android:title="@string/web_widget" />
         <item

--- a/Kotlin/app/src/main/res/menu/activity_main_drawer.xml
+++ b/Kotlin/app/src/main/res/menu/activity_main_drawer.xml
@@ -32,6 +32,9 @@
             android:id="@+id/nav_classic_interstitial"
             android:title="@string/classic_interstitial" />
         <item
+            android:id="@+id/nav_classic_interstitial_compose"
+            android:title="@string/classic_interstitial_compose" />
+        <item
             android:id="@+id/nav_web_widget"
             android:title="@string/web_widget" />
         <item

--- a/Kotlin/app/src/main/res/navigation/mobile_navigation.xml
+++ b/Kotlin/app/src/main/res/navigation/mobile_navigation.xml
@@ -60,6 +60,11 @@
         tools:layout="@layout/fragment_classic_interstitial" />
 
     <fragment
+        android:id="@+id/nav_classic_interstitial_compose"
+        android:name="com.taboola.kotlin.examples.screens.classic.ClassicInterstitialComposeFragment"
+        android:label="@string/classic_interstitial_compose" />
+
+    <fragment
         android:id="@+id/nav_web_widget"
         android:name="com.taboola.kotlin.examples.screens.web.WidgetFragment"
         android:label="@string/web_widget"

--- a/Kotlin/app/src/main/res/navigation/mobile_navigation.xml
+++ b/Kotlin/app/src/main/res/navigation/mobile_navigation.xml
@@ -53,6 +53,11 @@
         android:label="@string/classic_explore_more_compose"
         />
 
+    <fragment
+        android:id="@+id/nav_classic_interstitial"
+        android:name="com.taboola.kotlin.examples.screens.classic.InterstitialFragment"
+        android:label="@string/classic_interstitial"
+        tools:layout="@layout/fragment_classic_interstitial" />
 
     <fragment
         android:id="@+id/nav_web_widget"

--- a/Kotlin/app/src/main/res/values/strings.xml
+++ b/Kotlin/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="classic_explore_more">Classic Explore More</string>
     <string name="classic_explore_more_compose">Classic Explore More - Compose</string>
     <string name="classic_interstitial">Classic Interstitial</string>
+    <string name="classic_interstitial_compose">Classic Interstitial - Compose</string>
     <string name="web_widget">Web Widget</string>
     <string name="web_compose_widget">Web Widget - Compose</string>
     <string name="web_compose_feed">Web Feed - Compose</string>
@@ -32,7 +33,6 @@
     <string name="show_explore_more">Show Explore More</string>
     <string name="set_back_button_trigger">Set Back Button Trigger</string>
     <string name="explore_more_loading">Explore More Loading</string>
-    <string name="interstitial_custom_segment_hint">Custom segment</string>
     <string name="interstitial_loading">Loading Interstitial</string>
     <string name="interstitial_show">Show Interstitial</string>
     <string name="lorem_ipsum_long">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse egestas rutrum sollicitudin. Sed pulvinar ac leo vel dignissim. Vestibulum sit amet pulvinar justo, ac laoreet diam. Suspendisse in lectus quis neque mollis semper ac ut lorem. Vestibulum vulputate suscipit orci, non finibus mauris accumsan at. Ut ultrices est eros, et molestie magna egestas sit amet. Donec nec hendrerit nunc. Mauris ac blandit tellus, in pulvinar ipsum.

--- a/Kotlin/app/src/main/res/values/strings.xml
+++ b/Kotlin/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="classic_viewpager">Classic View Pager</string>
     <string name="classic_explore_more">Classic Explore More</string>
     <string name="classic_explore_more_compose">Classic Explore More - Compose</string>
+    <string name="classic_interstitial">Classic Interstitial</string>
     <string name="web_widget">Web Widget</string>
     <string name="web_compose_widget">Web Widget - Compose</string>
     <string name="web_compose_feed">Web Feed - Compose</string>
@@ -31,6 +32,9 @@
     <string name="show_explore_more">Show Explore More</string>
     <string name="set_back_button_trigger">Set Back Button Trigger</string>
     <string name="explore_more_loading">Explore More Loading</string>
+    <string name="interstitial_custom_segment_hint">Custom segment</string>
+    <string name="interstitial_loading">Loading Interstitial</string>
+    <string name="interstitial_show">Show Interstitial</string>
     <string name="lorem_ipsum_long">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse egestas rutrum sollicitudin. Sed pulvinar ac leo vel dignissim. Vestibulum sit amet pulvinar justo, ac laoreet diam. Suspendisse in lectus quis neque mollis semper ac ut lorem. Vestibulum vulputate suscipit orci, non finibus mauris accumsan at. Ut ultrices est eros, et molestie magna egestas sit amet. Donec nec hendrerit nunc. Mauris ac blandit tellus, in pulvinar ipsum.
                                     Aliquam lacinia auctor hendrerit. Fusce aliquet turpis ac tortor dignissim pellentesque. Morbi at odio ligula. Ut fermentum dui et libero feugiat euismod. Vestibulum auctor accumsan accumsan. Nam sit amet pretium lectus, eu vulputate ipsum. Mauris tempor mauris ac lorem cursus, lobortis bibendum neque fermentum. Integer lacinia ac neque id accumsan. Suspendisse placerat ac eros quis tempor.
                                     Vivamus posuere sapien nec metus egestas efficitur. Aliquam in lorem a nibh vulputate mattis. Quisque vestibulum at orci ut aliquam. Ut ornare euismod sollicitudin. Nulla eget facilisis neque. Proin at pulvinar eros, et iaculis urna. Donec a maximus nisi. Praesent suscipit mi quis sapien semper, id venenatis mauris dapibus. Morbi commodo augue erat, eget condimentum odio posuere at. Curabitur id condimentum mi. Sed scelerisque finibus magna, eget commodo arcu consectetur non. Vivamus quis dui porta, interdum justo volutpat, lacinia mauris. Curabitur risus mi, scelerisque ut magna in, lobortis mattis risus. Integer dui quam, luctus in nunc quis, volutpat semper eros. Mauris nec finibus libero.


### PR DESCRIPTION
Edit: Added the Interstitial Compose screen to the Kolin project.
Interstitial screens have been implemented in Java and Kotlin projects.

Java project:

<img width="200" height="550" alt="Screenshot_20260210_093905" src="https://github.com/user-attachments/assets/bde742b3-8e27-447f-a073-1994d2275436" />
<img width="200" height="550" alt="Screenshot_20260210_093909" src="https://github.com/user-attachments/assets/72ff058a-1392-40a5-9e58-ce29f61a77fc" />
<img width="200" height="550" alt="Screenshot_20260210_093914" src="https://github.com/user-attachments/assets/5906d28f-09e1-476a-8df1-a8458cf09a97" />

Kotlin project:

<img width="200" height="550" alt="Screenshot_20260210_092923" src="https://github.com/user-attachments/assets/70530ee1-2f0d-4387-9bcd-f08d44ee01df" />
<img width="200" height="550" alt="Screenshot_20260210_092932" src="https://github.com/user-attachments/assets/c83619fc-bac2-4519-95a6-be4a8ec133fa" />
<img width="200" height="550" alt="Screenshot_20260210_092940" src="https://github.com/user-attachments/assets/64743164-6a9d-4e29-ab6d-4c8aec98349e" />

Compose screen:

<img width="200" height="550" alt="Screenshot_20260213_083545" src="https://github.com/user-attachments/assets/dd60f167-b770-4816-a184-cc023e0fbcb0" />
<img width="200" height="550" alt="Screenshot_20260213_083552" src="https://github.com/user-attachments/assets/dffd7250-8760-4f50-ac59-148fdce5a233" />
<img width="200" height="550" alt="Screenshot_20260213_083558" src="https://github.com/user-attachments/assets/d43025d0-fbfa-4d05-bf63-cc8be0906724" />
